### PR TITLE
Compute torque PZ reachsets using regressor instead of rnea

### DIFF
--- a/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
@@ -17,10 +17,10 @@ KinovaWithGripperConservativePayloadInfo:
   # when the model uncertainty can not be represented as ratios
   end_effector_mass_lb: 1.2 # Kinova end effector with gripper should be about 1.2849 kg, this is a conservative estimate (lower bound)
   end_effector_mass_ub: 5.0 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
-  end_effector_com_lb: [-0.1, -0.1, -0.6]
+  end_effector_com_lb: [-0.1, -0.1, -0.8]
   end_effector_com_ub: [0.1, 0.1, -0.1]
-  end_effector_inertia_lb: [-0.1, -0.1, -0.1, -0.1, -0.1, -0.1]
-  end_effector_inertia_ub: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+  end_effector_inertia_lb: [-0.15, -0.15, -0.15, -0.15, -0.15, -0.15]
+  end_effector_inertia_ub: [0.15, 0.15, 0.15, 0.15, 0.15, 0.15]
 
   # ultimate bound for tracking error
   ultimate_bound:

--- a/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
@@ -19,14 +19,8 @@ KinovaWithoutGripper:
   end_effector_mass_ub: 4.0 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
   end_effector_com_lb: [-0.1, -0.1, -0.4]
   end_effector_com_ub: [0.1, 0.1, -0.1]
-  end_effector_inertia_lb: [-0.01, -0.01, -0.01, -0.01, -0.01, -0.01]
-  end_effector_inertia_ub: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
-  # end_effector_mass_lb: 2.63 # Kinova end effector with gripper should be about 1.2849 kg, this is a conservative estimate (lower bound)
-  # end_effector_mass_ub: 2.65 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
-  # end_effector_com_lb: [-0.01, -0.01, -0.35]
-  # end_effector_com_ub: [0.01, 0.01, -0.33]
-  # end_effector_inertia_lb: [-0.01, -0.01, -0.01, -0.01, -0.01, -0.01]
-  # end_effector_inertia_ub: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+  end_effector_inertia_lb: [-0.02, -0.02, -0.02, -0.02, -0.02, -0.02]
+  end_effector_inertia_ub: [0.02, 0.02, 0.02, 0.02, 0.02, 0.02]
 
   # ultimate bound for tracking error
   ultimate_bound:

--- a/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
@@ -1,4 +1,4 @@
-KinovaWithoutGripper:
+KinovaWithGripperConservativePayloadInfo:
   num_motors: 7
   num_joints: 7
   gravity: [0.0, 0.0, -9.81]
@@ -16,11 +16,11 @@ KinovaWithoutGripper:
   # this is specifically for end effector system identification,
   # when the model uncertainty can not be represented as ratios
   end_effector_mass_lb: 1.2 # Kinova end effector with gripper should be about 1.2849 kg, this is a conservative estimate (lower bound)
-  end_effector_mass_ub: 4.0 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
-  end_effector_com_lb: [-0.1, -0.1, -0.4]
+  end_effector_mass_ub: 5.0 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
+  end_effector_com_lb: [-0.1, -0.1, -0.6]
   end_effector_com_ub: [0.1, 0.1, -0.1]
-  end_effector_inertia_lb: [-0.02, -0.02, -0.02, -0.02, -0.02, -0.02]
-  end_effector_inertia_ub: [0.02, 0.02, 0.02, 0.02, 0.02, 0.02]
+  end_effector_inertia_lb: [-0.1, -0.1, -0.1, -0.1, -0.1, -0.1]
+  end_effector_inertia_ub: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
 
   # ultimate bound for tracking error
   ultimate_bound:

--- a/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithGripperConservativePayloadInfo.yaml
@@ -1,6 +1,6 @@
-KinovaWithSuctionCup:
+KinovaWithoutGripper:
   num_motors: 7
-  num_joints: 8 # this means there's an additional joint for the suction cup
+  num_joints: 7
   gravity: [0.0, 0.0, -9.81]
 
   # motor friction model: friction * sign(velocity) + damping * velocity + transmissionInertia * acceleration
@@ -9,9 +9,24 @@ KinovaWithSuctionCup:
   transmissionInertia: [8.03, 11.9962024615303644, 9.0025427861751517, 11.5806439316706360, 8.4665040917914123, 8.8537069373742430, 8.8587303664685315]
 
   # model uncertainty represented as ratios
-  mass_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20, 0.20]
-  com_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20, 0.20]
-  inertia_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20, 0.20]
+  mass_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+  com_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+  inertia_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+
+  # this is specifically for end effector system identification,
+  # when the model uncertainty can not be represented as ratios
+  end_effector_mass_lb: 1.2 # Kinova end effector with gripper should be about 1.2849 kg, this is a conservative estimate (lower bound)
+  end_effector_mass_ub: 4.0 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
+  end_effector_com_lb: [-0.1, -0.1, -0.4]
+  end_effector_com_ub: [0.1, 0.1, -0.1]
+  end_effector_inertia_lb: [-0.01, -0.01, -0.01, -0.01, -0.01, -0.01]
+  end_effector_inertia_ub: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+  # end_effector_mass_lb: 2.63 # Kinova end effector with gripper should be about 1.2849 kg, this is a conservative estimate (lower bound)
+  # end_effector_mass_ub: 2.65 # Kinova maximum payload is 3.0 kg, this is a conservative estimate (upper bound)
+  # end_effector_com_lb: [-0.01, -0.01, -0.35]
+  # end_effector_com_ub: [0.01, 0.01, -0.33]
+  # end_effector_inertia_lb: [-0.01, -0.01, -0.01, -0.01, -0.01, -0.01]
+  # end_effector_inertia_ub: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
 
   # ultimate bound for tracking error
   ultimate_bound:
@@ -20,11 +35,6 @@ KinovaWithSuctionCup:
     M_max: 15.79635774 # maximum eigenvalue of the inertia mass matrix
     M_min: 8.29938 # minimum eigenvalue of the inertia mass matrix
     Kr: 5.0 # robust controller parameter
-
-  # suction cup parameters
-  suction_force: 50.0 # N, maximum suction force
-  mu: 0.7 # translational friction coefficient over the suction cup surface
-  contact_surface_radius: 0.05 # m, radius of the suction cup
 
   # collision sphere representation for each link
   collision_spheres:
@@ -60,11 +70,16 @@ KinovaWithSuctionCup:
     - "offset": [0.0, -0.14, 0.0]
       "radius": 0.05
     joint_7:
-    - "offset": [-0.03, -0.06, -0.055]
+    - "offset": [-0.03, -0.06, -0.055] # camera
       "radius": 0.02
     - "offset": [0.0, -0.06, -0.055]
       "radius": 0.02
     - "offset": [0.03, -0.06, -0.055]
       "radius": 0.02
-
+    - "offset": [0.0, 0.0, -0.10] # gripper
+      "radius": 0.05
+    - "offset": [0.0, 0.0, -0.15]
+      "radius": 0.05
+    - "offset": [0.0, 0.0, -0.20]
+      "radius": 0.05
     

--- a/Examples/Kinova/Armour/KinovaWithGripperInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithGripperInfo.yaml
@@ -1,4 +1,4 @@
-KinovaWithoutGripper:
+KinovaWithGripper:
   num_motors: 7
   num_joints: 7
   gravity: [0.0, 0.0, -9.81]

--- a/Examples/Kinova/Armour/KinovaWithGripperInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithGripperInfo.yaml
@@ -2,20 +2,28 @@ KinovaWithoutGripper:
   num_motors: 7
   num_joints: 7
   gravity: [0.0, 0.0, -9.81]
+
+  # motor friction model: friction * sign(velocity) + damping * velocity + transmissionInertia * acceleration
   friction: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
   damping: [10.5, 7.4064845817230722, 9.9727633408172860, 8.2667950822503915, 8.8572249026528151, 8.7110831569332845, 8.8881903638306934]
   transmissionInertia: [8.03, 11.9962024615303644, 9.0025427861751517, 11.5806439316706360, 8.4665040917914123, 8.8537069373742430, 8.8587303664685315]
+
+  # model uncertainty represented as ratios
   mass_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
   com_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
   inertia_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+  
+  # ultimate bound for tracking error
   ultimate_bound:
-    alpha: 20.0
-    V_m: 0.02
-    M_max: 15.79635774
-    M_min: 8.29938
-    Kr: 5.0
+    alpha: 20.0 # robust controller parameter
+    V_m: 0.02 # robust controller parameter
+    M_max: 15.79635774 # maximum eigenvalue of the inertia mass matrix
+    M_min: 8.29938 # minimum eigenvalue of the inertia mass matrix
+    Kr: 5.0 # robust controller parameter
+
+  # collision sphere representation for each link
   collision_spheres:
-    joint_2:
+    joint_2: # the following spheres start from joint_2
     - "offset": [0.0, -0.05, -0.01]
       "radius": 0.06
     - "offset": [0.0, -0.11, -0.01]

--- a/Examples/Kinova/Armour/KinovaWithoutGripperInfo.yaml
+++ b/Examples/Kinova/Armour/KinovaWithoutGripperInfo.yaml
@@ -2,20 +2,28 @@ KinovaWithoutGripper:
   num_motors: 7
   num_joints: 7
   gravity: [0.0, 0.0, -9.81]
+
+  # motor friction model: friction * sign(velocity) + damping * velocity + transmissionInertia * acceleration
   friction: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
   damping: [10.5, 7.4064845817230722, 9.9727633408172860, 8.2667950822503915, 8.8572249026528151, 8.7110831569332845, 8.8881903638306934]
   transmissionInertia: [8.03, 11.9962024615303644, 9.0025427861751517, 11.5806439316706360, 8.4665040917914123, 8.8537069373742430, 8.8587303664685315]
-  mass_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
-  com_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
-  inertia_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05]
+
+  # model uncertainty represented as ratios
+  mass_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+  com_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+  inertia_uncertainty: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.20]
+
+  # ultimate bound for tracking error
   ultimate_bound:
-    alpha: 10.0
-    V_m: 0.01
-    M_max: 15.79635774
-    M_min: 8.29938
-    Kr: 5.0
+    alpha: 20.0 # robust controller parameter
+    V_m: 0.02 # robust controller parameter
+    M_max: 15.79635774 # maximum eigenvalue of the inertia mass matrix
+    M_min: 8.29938 # minimum eigenvalue of the inertia mass matrix
+    Kr: 5.0 # robust controller parameter
+
+  # collision sphere representation for each link
   collision_spheres:
-    joint_2:
+    joint_2: # the following spheres start from joint_2
     - "offset": [0.0, -0.05, -0.01]
       "radius": 0.06
     - "offset": [0.0, -0.11, -0.01]

--- a/Examples/Kinova/Armour/include/PZDynamics.h
+++ b/Examples/Kinova/Armour/include/PZDynamics.h
@@ -3,6 +3,7 @@
 
 #include "pinocchio/algorithm/model.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
+#include "pinocchio/algorithm/regressor.hpp"
 #include "pinocchio/algorithm/kinematics.hpp"
 #include "pinocchio/algorithm/frames.hpp"
 
@@ -38,6 +39,9 @@ public:
 
 	std::shared_ptr<RobotInfo> robotInfoPtr_ = nullptr;
 	std::shared_ptr<BezierCurveInterval> trajPtr_ = nullptr;
+
+	VecX phi;
+	Eigen::Vector<Interval, Eigen::Dynamic> phi_interval;
 
 	std::vector<pinocchio::ModelTpl<PZSparse>> model_sparses;
 	std::vector<pinocchio::DataTpl<PZSparse>> data_sparses;

--- a/Examples/Kinova/Armour/include/PZSparse.h
+++ b/Examples/Kinova/Armour/include/PZSparse.h
@@ -10,7 +10,7 @@ namespace Armour {
 using namespace boost::multiprecision;
 
 // make sure the number of monomials in a PZSparse is always smaller than this number
-#define PZ_ORDER 30
+#define PZ_ORDER 20
 
 // For now we only support 7 variables and the number is hardcoded unfortunately
 // The degree of the robot has to be 7.
@@ -69,6 +69,8 @@ public:
     PZSparse(double center_inp);
 
     PZSparse(double center_inp, double uncertainty_percent);
+
+    PZSparse(const Interval a);
 
     PZSparse(double center_inp, Interval independent_inp);
 

--- a/Examples/Kinova/Armour/include/RobotInfo.h
+++ b/Examples/Kinova/Armour/include/RobotInfo.h
@@ -89,7 +89,8 @@ public:
                                                 const double inertia_eps);
 
     void change_endeffector_inertial_parameters(const Vec10& inertial_parameters,
-                                                const Vec10& inertial_parameters_eps);
+                                                const Vec10& inertial_parameters_lb,
+                                                const Vec10& inertial_parameters_ub);
 
     void print() const;
 };

--- a/Examples/Kinova/Armour/include/RobotInfo.h
+++ b/Examples/Kinova/Armour/include/RobotInfo.h
@@ -46,9 +46,22 @@ public:
 
     pinocchio::Model model;
 
+    // model uncertainty
     VecX mass_uncertainty;
     VecX com_uncertainty;
     VecX inertia_uncertainty;
+
+    // the following are specifically for the end effector
+    // if defined, these will overwrite the previous model uncertainty 
+    // (for example, the last element of the mass_uncertainty vector is the end effector mass uncertainty,
+    // but will be ignored if end_effector_mass_lb and end_effector_mass_ub are defined)
+    bool if_end_effector_info_exist = false;
+    double end_effector_mass_lb = 0;
+    double end_effector_mass_ub = 0;
+    Vec3 end_effector_com_lb;
+    Vec3 end_effector_com_ub;
+    Vec6 end_effector_inertia_lb;
+    Vec6 end_effector_inertia_ub;
 
     ultimate_bound ultimate_bound_info;
 

--- a/Examples/Kinova/Armour/src/PZDynamics.cpp
+++ b/Examples/Kinova/Armour/src/PZDynamics.cpp
@@ -176,12 +176,12 @@ void PZDynamics::compute() {
 
             pinocchio::forwardKinematics(model_sparses[t_ind], data_sparses[t_ind], q);
             pinocchio::updateFramePlacements(model_sparses[t_ind], data_sparses[t_ind]);
-            pinocchio::rnea(model_sparses[t_ind], data_sparses[t_ind], q, qd, qdd);
+            // pinocchio::rnea(model_sparses[t_ind], data_sparses[t_ind], q, qd, qdd);
             // pinocchio::rnea(model_sparses_interval[t_ind], data_sparses_interval[t_ind], q, qd, qdd);
             pinocchio::computeJointTorqueRegressor(model_sparses[t_ind], data_sparses[t_ind], q, qd, qdd);
 
             for (int i = 0; i < num_joints; i++) {
-                data_sparses[t_ind].tau(i) = 0;
+                data_sparses[t_ind].tau(i) = 0.0;
                 data_sparses_interval[t_ind].tau(i) = 0.0;
                 for (int j = 0; j < 10 * num_joints; j++) {
                     data_sparses[t_ind].tau(i) += data_sparses[t_ind].jointTorqueRegressor(i, j) * phi(j);

--- a/Examples/Kinova/Armour/src/PZSparse.cpp
+++ b/Examples/Kinova/Armour/src/PZSparse.cpp
@@ -51,6 +51,10 @@ PZSparse::PZSparse(double center_inp, double uncertainty_percent) {
     independent = fabs(uncertainty_percent * center_inp);
 }
 
+PZSparse::PZSparse(const Interval a) {
+    center = getCenter(a);
+    independent = getRadius(a);
+}
 
 PZSparse::PZSparse(double center_inp, Interval independent_inp) {
     center = center_inp + getCenter(independent_inp);

--- a/Examples/Kinova/Armour/src/RobotInfo.cpp
+++ b/Examples/Kinova/Armour/src/RobotInfo.cpp
@@ -87,6 +87,41 @@ RobotInfo::RobotInfo(const std::string& urdf_filename,
     com_uncertainty = map_to_vector(RobotConfig["com_uncertainty"], num_joints);
     inertia_uncertainty = map_to_vector(RobotConfig["inertia_uncertainty"], num_joints);
 
+    if (RobotConfig["end_effector_mass_lb"].IsDefined() &&
+        RobotConfig["end_effector_mass_ub"].IsDefined() &&
+        RobotConfig["end_effector_com_lb"].IsDefined() &&
+        RobotConfig["end_effector_com_ub"].IsDefined() &&
+        RobotConfig["end_effector_inertia_lb"].IsDefined() &&
+        RobotConfig["end_effector_inertia_ub"].IsDefined()) {
+        if_end_effector_info_exist = true;
+        end_effector_mass_lb = RobotConfig["end_effector_mass_lb"].as<double>();
+        end_effector_mass_ub = RobotConfig["end_effector_mass_ub"].as<double>();
+        end_effector_com_lb = map_to_vector(RobotConfig["end_effector_com_lb"], 3);
+        end_effector_com_ub = map_to_vector(RobotConfig["end_effector_com_ub"], 3);
+        end_effector_inertia_lb = map_to_vector(RobotConfig["end_effector_inertia_lb"], 6);
+        end_effector_inertia_ub = map_to_vector(RobotConfig["end_effector_inertia_ub"], 6);
+
+        // consistency check
+        const double mass = model.inertias[model.nv].mass();
+        if (end_effector_mass_lb > mass ||
+            end_effector_mass_ub < mass) {
+            std::cerr << mass << " [" << end_effector_mass_lb << ", " << end_effector_mass_ub << "]\n";
+            throw std::runtime_error("End effector mass bounds are not within the range of the original mass.");
+        }
+        const Vec3& com = model.inertias[model.nv].lever();
+        if ((end_effector_com_lb - com).minCoeff() > 0 ||
+            (end_effector_com_ub - com).maxCoeff() < 0) {
+            std::cerr << com.transpose() << "\n[" << end_effector_com_lb.transpose() << ",\n " << end_effector_com_ub.transpose() << "]\n";
+            throw std::runtime_error("End effector com bounds are not within the range of the original com.");
+        }
+        const Vec6& inertia = model.inertias[model.nv].inertia().data();
+        if ((end_effector_inertia_lb - inertia).minCoeff() > 0 ||
+            (end_effector_inertia_ub - inertia).maxCoeff() < 0) {
+            std::cerr << inertia.transpose() << "\n[" << end_effector_inertia_lb.transpose() << ",\n " << end_effector_inertia_ub.transpose() << "]\n";
+            throw std::runtime_error("End effector inertia bounds are not within the range of the original inertia.");
+        }
+    }
+
     try {
         const YAML::Node& ultimate_bound_node = RobotConfig["ultimate_bound"];
         ultimate_bound_info.alpha = ultimate_bound_node["alpha"].as<double>();

--- a/Examples/Kinova/InverseKinematics/src/KinovaIKMotionPybindWrapper.cpp
+++ b/Examples/Kinova/InverseKinematics/src/KinovaIKMotionPybindWrapper.cpp
@@ -14,6 +14,9 @@ KinovaIKMotionPybindWrapper::KinovaIKMotionPybindWrapper(const std::string urdf_
     app = IpoptApplicationFactory();
     app->Options()->SetStringValue("hessian_approximation", "exact");
 
+    // Note that this is the transformation matrix from the last joint to the contact point of the gripper
+    // This is hardcoded for Kinova-gen3
+    // Refer to the urdf (the last two fixed joints) for more information
     Transform endT1(Eigen::Vector3d(M_PI, 0, 0), Eigen::Vector3d(0, 0, -0.061525)); // end effector -> gripper base
     Transform endT2(Eigen::Vector3d(0, 0, M_PI_2), Eigen::Vector3d(0, 0, 0.12)); // gripper base -> contact joint
     endT = endT1 * endT2;

--- a/Examples/Kinova/InverseKinematics/src/KinovaIKMotionPybindWrapper.cpp
+++ b/Examples/Kinova/InverseKinematics/src/KinovaIKMotionPybindWrapper.cpp
@@ -110,6 +110,7 @@ nb::tuple KinovaIKMotionPybindWrapper::solve(const nb_1d_double& initial_guess) 
     }
 
     int pid = 0;
+    has_optimized = true;
     for (const auto& desiredTransform: desiredTransforms) {
         try {
             mynlp->reset();

--- a/Examples/Kinova/SystemIdentification/ExcitingTrajectories/SafePayloadExcitingPybind.cpp
+++ b/Examples/Kinova/SystemIdentification/ExcitingTrajectories/SafePayloadExcitingPybind.cpp
@@ -16,6 +16,7 @@ NB_MODULE(safe_payload_exciting_nanobind, m) {
         .def("set_obstacles", &SafePayloadExcitingPybindWrapper::set_obstacles)
         .def("set_ipopt_parameters", &SafePayloadExcitingPybindWrapper::set_ipopt_parameters)
         .def("set_trajectory_parameters", &SafePayloadExcitingPybindWrapper::set_trajectory_parameters)
+        .def("set_endeffector_inertial_parameters", &SafePayloadExcitingPybindWrapper::set_endeffector_inertial_parameters)
         .def("optimize", &SafePayloadExcitingPybindWrapper::optimize)
         .def("analyze_solution", &SafePayloadExcitingPybindWrapper::analyze_solution);
 }

--- a/Examples/Kinova/SystemIdentification/ExcitingTrajectories/include/SafePayloadExcitingPybindWrapper.h
+++ b/Examples/Kinova/SystemIdentification/ExcitingTrajectories/include/SafePayloadExcitingPybindWrapper.h
@@ -20,6 +20,7 @@ class SafePayloadExcitingPybindWrapper {
 public:
     using Model = pinocchio::Model;
     using Vec3 = Eigen::Vector3d;
+    using Vec10 = Eigen::Vector<double, 10>;
     using VecX = Eigen::VectorXd;
     using MatX = Eigen::MatrixXd;
 
@@ -54,6 +55,10 @@ public:
                                    const nb_1d_float k_center_inp,
                                    const nb_1d_float k_range_inp,
                                    const double duration_inp);
+
+    void set_endeffector_inertial_parameters(const nb_1d_float inertial_parameters,
+                                             const nb_1d_float inertial_parameters_lb,
+                                             const nb_1d_float inertial_parameters_ub);
 
     nb::tuple optimize();
 

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/EndEffectorIdentificationPybind.cpp
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/EndEffectorIdentificationPybind.cpp
@@ -17,5 +17,7 @@ NB_MODULE(end_effector_sysid_nanobind , m) {
                       const std::string, 
                       const bool>())
         .def("set_ipopt_parameters", &EndEffectorIdentificationPybindWrapper::set_ipopt_parameters)
-        .def("optimize", &EndEffectorIdentificationPybindWrapper::optimize);
+        .def("add_trajectory_file", &EndEffectorIdentificationPybindWrapper::add_trajectory_file)
+        .def("optimize", &EndEffectorIdentificationPybindWrapper::optimize)
+        .def("reset", &EndEffectorIdentificationPybindWrapper::reset);
 }

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/TestEndEffectorParametersIdentification.cpp
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/TestEndEffectorParametersIdentification.cpp
@@ -78,13 +78,13 @@ int main(int argc, char* argv[]) {
     double setup_time = 0;
     try {
         auto start = std::chrono::high_resolution_clock::now();
-	    mynlp->set_parameters(model, 
-                              trajectory_filename,
-                              sensor_noise,
-                              H,
-                              TimeFormat::Nanosecond,
-                              downsample_rate,
+	    mynlp->set_parameters(model,
                               offset);
+        mynlp->add_trajectory_file(trajectory_filename,
+                                   sensor_noise,
+                                   H,
+                                   TimeFormat::Nanosecond,
+                                   downsample_rate);
         auto end = std::chrono::high_resolution_clock::now();
         setup_time = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
         std::cout << "Setup time: " << setup_time << " milliseconds.\n";

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/include/EndEffectorIdentificationPybindWrapper.h
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/include/EndEffectorIdentificationPybindWrapper.h
@@ -48,7 +48,11 @@ public:
                               const std::string linear_solver,
                               const bool gradient_check);
 
-    nb::tuple optimize(const std::vector<std::string>& trajectory_filenames);
+    void add_trajectory_file(const std::string filename_input);
+
+    nb::tuple optimize();
+
+    void reset();
 
     // class members
         // robot model

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/include/EndEffectorParametersIdentification.h
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/include/EndEffectorParametersIdentification.h
@@ -137,6 +137,7 @@ public:
    
     std::vector<std::shared_ptr<TrajectoryData>> trajPtrs_;
     std::vector<std::shared_ptr<TrajectoryData>> trajPtrs2_;
+    std::vector<std::string> trajectoryFilenames_;
 
     std::shared_ptr<MomentumRegressor> mrPtr_;
     std::shared_ptr<RegressorInverseDynamics> ridPtr_;

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/include/EndEffectorParametersIdentification.h
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/include/EndEffectorParametersIdentification.h
@@ -31,24 +31,15 @@ public:
     // [set_parameters]
     bool set_parameters(
         const Model& model_input,
+        const VecXd offset_input = VecXd::Zero(0)
+    );
+
+    void add_trajectory_file(
         const std::string filename_input,
         const SensorNoiseInfo sensor_noise_input = SensorNoiseInfo(),
         const int H_input = 10,
         const TimeFormat time_format = TimeFormat::Second,
-        const int downsample_rate = 1,
-        const VecXd offset_input = VecXd::Zero(0)
-    );
-
-    // [set_parameters]
-    bool set_parameters(
-        const Model& model_input,
-        const std::vector<std::string>& filenames_input,
-        const SensorNoiseInfo sensor_noise_input = SensorNoiseInfo(),
-        const int H_input = 10,
-        const TimeFormat time_format = TimeFormat::Second,
-        const int downsample_rate = 1,
-        const VecXd offset_input = VecXd::Zero(0)
-    );
+        const int downsample_rate = 1);
 
     // [initialize_regressors]
     void initialize_regressors(const std::shared_ptr<TrajectoryData>& trajPtr_,
@@ -153,8 +144,6 @@ public:
     // std::shared_ptr<IntervalMomentumRegressor> mrIntPtr_ = nullptr;
     // std::shared_ptr<IntervalRegressorInverseDynamics> ridIntPtr_ = nullptr;
 
-    VecXd weights; // weights for the nonlinear least square problem
-
         // forward integration horizon
     int H = 10;
     std::vector<int> num_segments;
@@ -169,9 +158,6 @@ public:
 
     MatXd A; // regression matrix for all trajectories
     VecXd b; // regression vector for all trajectories
-
-    MatXd Aweighted;
-    VecXd bweighted;
 
     Index nonzero_weights = 0;
 

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/src/EndEffectorIdentificationPybindWrapper.cpp
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/src/EndEffectorIdentificationPybindWrapper.cpp
@@ -116,6 +116,11 @@ nb::tuple EndEffectorIdentificationPybindWrapper::optimize() {
         throw std::runtime_error("Trajectory data not added yet!");
     }
 
+    std::cout << "The following trajectory data files are considered:\n";
+    for (const auto& filename: mynlp->trajectoryFilenames_) {
+        std::cout << "    Trajectory file: " << filename << std::endl;
+    }
+
     // Initialize the IpoptApplication and process the options
     ApplicationReturnStatus status;
     status = app->Initialize();

--- a/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/src/EndEffectorIdentificationPybindWrapper.cpp
+++ b/Examples/Kinova/SystemIdentification/IterativeSystemIdentification/src/EndEffectorIdentificationPybindWrapper.cpp
@@ -61,6 +61,8 @@ EndEffectorIdentificationPybindWrapper::EndEffectorIdentificationPybindWrapper(c
     // set up the Ipopt problem
     mynlp = new EndEffectorParametersIdentification();
     mynlp->display_info = display_info;
+    mynlp->set_parameters(model,
+                          offset);
 
     app = IpoptApplicationFactory();
 }
@@ -91,38 +93,27 @@ void EndEffectorIdentificationPybindWrapper::set_ipopt_parameters(const double t
     set_ipopt_parameters_check = true;
 }
 
-nb::tuple EndEffectorIdentificationPybindWrapper::optimize(const std::vector<std::string>& trajectory_filenames) {
-    if (!set_ipopt_parameters_check ) {
-        throw std::runtime_error("parameters not set properly!");
-    }
-    // Initialize optimizer
-    double setup_time = 0;
+void EndEffectorIdentificationPybindWrapper::add_trajectory_file(const std::string filename_input) {
     try {
-        auto start = std::chrono::high_resolution_clock::now();
-
-        mynlp->reset();
-        mynlp->set_parameters(model, 
-                              trajectory_filenames,
-                              sensor_noise,
-                              H,
-                              time_format,
-                              downsample_rate,
-                              offset);
-
-        if (mynlp->enable_hessian) {
-            app->Options()->SetStringValue("hessian_approximation", "exact");
-        }
-        else {
-            app->Options()->SetStringValue("hessian_approximation", "limited-memory");
-        }
-
-        auto end = std::chrono::high_resolution_clock::now();
-        setup_time = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-        std::cout << "System identification setup time: " << setup_time << " milliseconds.\n";
+        mynlp->add_trajectory_file(filename_input,
+                                   sensor_noise,
+                                   H,
+                                   time_format,
+                                   downsample_rate);
     }
     catch (std::exception& e) {
         std::cerr << e.what() << std::endl;
-        throw std::runtime_error("Error initializing Ipopt class! Check previous error message!");
+        throw std::runtime_error("Error adding trajectory file! Check previous error message!");
+    }
+}
+
+nb::tuple EndEffectorIdentificationPybindWrapper::optimize() {
+    if (!set_ipopt_parameters_check) {
+        throw std::runtime_error("parameters not set properly!");
+    }
+
+    if (mynlp->A.rows() == 0) {
+        throw std::runtime_error("Trajectory data not added yet!");
     }
 
     // Initialize the IpoptApplication and process the options
@@ -134,30 +125,22 @@ nb::tuple EndEffectorIdentificationPybindWrapper::optimize(const std::vector<std
 
     // Run ipopt to solve the optimization problem
     double solve_time = 0;
-    for (int iter = 0; iter < 1; iter++) {
-        try {
-            auto start = std::chrono::high_resolution_clock::now();
+    try {
+        auto start = std::chrono::high_resolution_clock::now();
 
-            // Ask Ipopt to solve the problem
-            status = app->OptimizeTNLP(mynlp);
+        // Ask Ipopt to solve the problem
+        status = app->OptimizeTNLP(mynlp);
 
-            auto end = std::chrono::high_resolution_clock::now();
-            solve_time = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-            std::cout << "Iteration " << iter << " system identification solve time: " << solve_time << " milliseconds.\n";
-        }
-        catch (std::exception& e) {
-            throw std::runtime_error("Error solving optimization problem! Check previous error message!");
-        }
-
-        std::cout << "Iteration " << iter << std::endl;
-        std::cout << "    theta solution: " << mynlp->theta_solution.transpose() << std::endl;
-        std::cout << "    theta uncertainties: " << mynlp->theta_uncertainty.transpose() << std::endl;
-
-        if (mynlp->obj_value_copy < 1e-4 || 
-            mynlp->nonzero_weights < 0.5 * mynlp->b.size()) {
-            break;
-        }
+        auto end = std::chrono::high_resolution_clock::now();
+        solve_time = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+        std::cout << "System identification solve time: " << solve_time << " milliseconds.\n";
     }
+    catch (std::exception& e) {
+        throw std::runtime_error("Error solving optimization problem! Check previous error message!");
+    }
+
+    std::cout << "    theta solution: " << mynlp->theta_solution.transpose() << std::endl;
+    std::cout << "    theta uncertainties: " << mynlp->theta_uncertainty.transpose() << std::endl;
 
     const size_t shape_ptr[] = {10};
     auto result1 = nb::ndarray<nb::numpy, const double>(mynlp->theta_solution.data(),
@@ -171,6 +154,10 @@ nb::tuple EndEffectorIdentificationPybindWrapper::optimize(const std::vector<std
                                                         nb::handle()); 
 
     return nb::make_tuple(result1, result2);
+}
+
+void EndEffectorIdentificationPybindWrapper::reset() {
+    mynlp->reset();
 }
     
 }; // namespace Kinova

--- a/Robots/kinova-gen3/gen3_2f85.urdf
+++ b/Robots/kinova-gen3/gen3_2f85.urdf
@@ -15,7 +15,7 @@
   <ros2_control name="gen3_KortexMultiInterfaceHardware" type="system">
     <hardware>
       <plugin>kortex2_driver/KortexMultiInterfaceHardware</plugin>
-      <param name="robot_ip">192.168.11.11</param>
+      <param name="robot_ip">192.168.1.10</param>
       <param name="username">admin</param>
       <param name="password">admin</param>
       <param name="port">10000</param>

--- a/Robots/kinova-gen3/gen3_2f85_fixed.urdf
+++ b/Robots/kinova-gen3/gen3_2f85_fixed.urdf
@@ -15,7 +15,7 @@
   <ros2_control name="gen3_KortexMultiInterfaceHardware" type="system">
     <hardware>
       <plugin>kortex2_driver/KortexMultiInterfaceHardware</plugin>
-      <param name="robot_ip">192.168.11.11</param>
+      <param name="robot_ip">192.168.1.10</param>
       <param name="username">admin</param>
       <param name="password">admin</param>
       <param name="port">10000</param>

--- a/Robots/kinova-gen3/gen3_2f85_fixed_object.urdf
+++ b/Robots/kinova-gen3/gen3_2f85_fixed_object.urdf
@@ -15,7 +15,7 @@
   <ros2_control name="gen3_KortexMultiInterfaceHardware" type="system">
     <hardware>
       <plugin>kortex2_driver/KortexMultiInterfaceHardware</plugin>
-      <param name="robot_ip">192.168.11.11</param>
+      <param name="robot_ip">192.168.1.10</param>
       <param name="username">admin</param>
       <param name="password">admin</param>
       <param name="port">10000</param>

--- a/Robots/kinova-gen3/kinova_grasp_fixed.urdf
+++ b/Robots/kinova-gen3/kinova_grasp_fixed.urdf
@@ -291,8 +291,6 @@
     </collision>
   </link>
 
-
-
   <link name="gripper_right_spring_link">
     <inertial>
       <origin rpy="0 0 0" xyz="-9.7222E-12 0.028253 6.791E-10"/>
@@ -600,4 +598,34 @@
     <child link="gripper_left_pad"/>
     <axis xyz="0 0 0"/>
   </joint>
+
+  <!-- <joint name="gripper_dumbbell_joint" type="fixed">
+    <parent link="gripper_base"/>
+    <child link="gripper_dumbbell_approx"/>
+    <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.10155 0"/>
+  </joint>
+
+  <link name="gripper_dumbbell_approx">
+    <inertial>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <mass value="0.90718474"/>
+      <inertia ixx="0.0082732" ixy="0" ixz="-0.0000023" iyy="0.0031941" iyz="-0.0000033" izz="0.0062402"/>
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0.102"/>
+      <geometry>
+        <mesh filename="../objects/cube.obj"/>
+      </geometry>
+      <material name="">
+        <color rgba="0.89804 0.91765 0.92941 0.25"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <mesh filename="../objects/cube.obj"/>
+      </geometry>
+    </collision>
+  </link> -->
+  
 </robot>

--- a/Trajectories/src/TrajectoryData.cpp
+++ b/Trajectories/src/TrajectoryData.cpp
@@ -69,7 +69,7 @@ TrajectoryData::TrajectoryData(const std::string& filename_input,
         }
     }
 
-    T = tspan(N - 1);
+    T = tspan(N - 1) - tspan(0);
 
     // output information
     std::cout << "TrajectoryData: " << N << " data points loaded from " << filename_input << std::endl;
@@ -246,7 +246,7 @@ TrajectoryData::TrajectoryData(const std::vector<std::string>& filenames_input,
         }
     }
 
-    T = tspan(N - 1);
+    T = tspan(N - 1) - tspan(0);
 
     // output information
     std::cout << "TrajectoryData: " << N << " data points loaded from a sequence of files" << std::endl;


### PR DESCRIPTION
Computing torque PZ reachsets using regressor only requires one call to the recursive Newton Euler algorithms, that computes torque reachsets for both nominal model and interval model. The original method needs two calls to rnea.
The new method results in a smaller bound for model uncertainty, but longer computation time (one call to pinocchio::computeJointTorqueRegressor seems to take longer than two calls to pinocchio::rnea).